### PR TITLE
Add Steam and PSN achievement exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# PSN and Steam Achievement Data Scraper
+
+Two lightweight CLI tools for exporting global achievement/trophy data from Steam and PlayStation Network into tidy CSV files.
+
+## Steam achievements (Python)
+
+### Setup
+1. `cd steam`
+2. `python -m venv .venv`
+3. Activate the virtual environment: `. .venv/bin/activate` (macOS/Linux) or `.venv\Scripts\activate` (Windows)
+4. `pip install -r requirements.txt`
+5. Copy `.env.example` to `.env` and set `STEAM_API_KEY`
+
+### Run
+- `python steam_achievements.py --appid 620`
+- `python steam_achievements.py --appid 620 --lang french --out portal2_fr.csv`
+
+### Output CSV columns
+`api_name,title,description,hidden,icon,icon_gray,global_percent`
+
+## PlayStation trophies (TypeScript/Node)
+
+### Setup
+1. `cd psn`
+2. `npm install`
+3. Copy `.env.example` to `.env` and set `PSN_NPSSO`
+
+### Run
+- `npm start -- --query "Astro's Playroom"`
+- `npm start -- --query "Ghost of Tsushima" --group base --out got_base.csv`
+
+### Output CSV columns
+`trophy_id,name,description,rarity_bucket,earned_rate_pct,hidden,icon,np_communication_id,group_id`
+
+## Notes
+- Steam hidden achievements may lack descriptions until unlocked.
+- PSN endpoints rely on community documentation and require your own account credentials. Respect Sony's Terms of Service.
+- Text localization depends on the Steam `--lang` option and your PSN account region.

--- a/psn/.env.example
+++ b/psn/.env.example
@@ -1,0 +1,2 @@
+# Rename to .env and set your NPSSO token from PlayStation Network
+PSN_NPSSO=

--- a/psn/package.json
+++ b/psn/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "psn-trophies",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc",
+    "start": "ts-node src/psn_trophies.ts"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "psn-api": "^1.20.1"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/psn/src/psn_trophies.ts
+++ b/psn/src/psn_trophies.ts
@@ -1,0 +1,303 @@
+#!/usr/bin/env ts-node
+import fs from "fs";
+import path from "path";
+import process from "process";
+
+import { config as loadEnv } from "dotenv";
+import {
+  exchangeCodeForAccessToken,
+  exchangeNpssoForCode,
+  getTitleTrophies,
+  getTitleTrophyGroups,
+  makeUniversalSearch,
+} from "psn-api";
+
+loadEnv();
+
+class CliError extends Error {
+  constructor(message: string, public readonly exitCode: number) {
+    super(message);
+  }
+}
+
+type Authorization = Awaited<ReturnType<typeof exchangeCodeForAccessToken>>;
+
+type TrophyRow = {
+  trophy_id: string;
+  name: string;
+  description: string;
+  rarity_bucket: string;
+  earned_rate_pct: number | "";
+  hidden: "true" | "false";
+  icon: string;
+  np_communication_id: string;
+  group_id: string;
+};
+
+type TrophyGroupChoice = "all" | "base";
+
+type CliOptions = {
+  helpRequested: boolean;
+  query?: string;
+  group: TrophyGroupChoice;
+  out?: string;
+};
+
+function printHelp(): void {
+  const help = `Usage: ts-node psn_trophies.ts --query "<game name>" [--group all|base] [--out <file>]
+
+Fetch PlayStation Network trophy data and export it as CSV.
+
+Examples:
+  npm start -- --query "Astro's Playroom"
+  npm start -- --query "Ghost of Tsushima" --group base --out got_base.csv`;
+  console.log(help);
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { helpRequested: false, group: "all" };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "-h":
+      case "--help":
+        options.helpRequested = true;
+        break;
+      case "--query": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new CliError("Missing value for --query", 2);
+        }
+        options.query = value;
+        i += 1;
+        break;
+      }
+      case "--group": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new CliError("Missing value for --group", 2);
+        }
+        if (value !== "all" && value !== "base") {
+          throw new CliError("--group must be 'all' or 'base'", 2);
+        }
+        options.group = value;
+        i += 1;
+        break;
+      }
+      case "--out": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new CliError("Missing value for --out", 2);
+        }
+        options.out = value;
+        i += 1;
+        break;
+      }
+      default:
+        throw new CliError(`Unknown argument: ${arg}`, 2);
+    }
+  }
+
+  return options;
+}
+
+function ensureQuery(options: CliOptions): string {
+  if (!options.query || !options.query.trim()) {
+    throw new CliError("Missing required --query argument", 2);
+  }
+  return options.query.trim();
+}
+
+export async function authFromNpsso(npsso: string): Promise<Authorization> {
+  if (!npsso) {
+    throw new CliError("Missing PSN_NPSSO environment variable", 2);
+  }
+  try {
+    const code = await exchangeNpssoForCode(npsso);
+    return await exchangeCodeForAccessToken(code);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CliError(`PSN authentication failed: ${message}`, 3);
+  }
+}
+
+export async function findNpCommunicationId(
+  authorization: Authorization,
+  gameQuery: string,
+): Promise<string> {
+  try {
+    const searchResponse: any = await makeUniversalSearch(authorization, gameQuery);
+    const domainResponses: any[] = searchResponse?.domainResponses ?? [];
+    const candidates = domainResponses.flatMap((domain) => domain?.results ?? []);
+    const gameResult = candidates.find((result) => {
+      const type = (result?.mediaType ?? result?.type ?? "").toString().toLowerCase();
+      return type.includes("game");
+    });
+    const npCommunicationId =
+      gameResult?.id?.npCommunicationId ||
+      gameResult?.id?.communicationId ||
+      gameResult?.id?.value ||
+      gameResult?.metadata?.npCommunicationId;
+    if (!npCommunicationId) {
+      throw new Error("No game results contained an NP Communication ID.");
+    }
+    return npCommunicationId;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CliError(`Failed to resolve NP Communication ID: ${message}`, 3);
+  }
+}
+
+function normalizeGroupId(groupId: string | undefined): string {
+  if (!groupId || groupId === "default") {
+    return "default";
+  }
+  return groupId;
+}
+
+function parseEarnedRate(raw: any): number | "" {
+  if (raw === undefined || raw === null || raw === "") {
+    return "";
+  }
+  const value = Number.parseFloat(String(raw));
+  return Number.isFinite(value) ? Number(value.toFixed(2)) : "";
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-")
+    .slice(0, 64) || "query";
+}
+
+export async function fetchTrophies(
+  authorization: Authorization,
+  npCommunicationId: string,
+  group: TrophyGroupChoice,
+): Promise<TrophyRow[]> {
+  try {
+    const trophyGroupsResponse: any = await getTitleTrophyGroups(authorization, npCommunicationId);
+    const groups: any[] = trophyGroupsResponse?.trophyGroups ?? [];
+    const filteredGroups = group === "base"
+      ? groups.filter((item) => normalizeGroupId(item?.trophyGroupId) === "default")
+      : groups;
+
+    const targetGroups = filteredGroups.length > 0 ? filteredGroups : [{ trophyGroupId: "default" }];
+
+    const allRows: TrophyRow[] = [];
+    for (const groupInfo of targetGroups) {
+      const groupId = normalizeGroupId(groupInfo?.trophyGroupId);
+      const trophiesResponse: any = await getTitleTrophies(
+        authorization,
+        npCommunicationId,
+        groupId,
+      );
+      const trophies: any[] = trophiesResponse?.trophies ?? [];
+      for (const trophy of trophies) {
+        const rarity = trophy?.trophyRare ?? trophy?.rarity ?? "";
+        const earnedRate = parseEarnedRate(trophy?.trophyEarnedRate ?? trophy?.earnedRate ?? "");
+        allRows.push({
+          trophy_id: String(trophy?.trophyId ?? ""),
+          name: trophy?.trophyName ?? trophy?.name ?? "",
+          description: trophy?.trophyDetail ?? trophy?.detail ?? "",
+          rarity_bucket: typeof rarity === "string" ? rarity : String(rarity ?? ""),
+          earned_rate_pct: earnedRate,
+          hidden: trophy?.trophyHidden ? "true" : "false",
+          icon: trophy?.trophyIconUrl ?? trophy?.iconUrl ?? "",
+          np_communication_id: npCommunicationId,
+          group_id: groupId === "default" ? "" : groupId,
+        });
+      }
+    }
+
+    return sortRows(allRows);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CliError(`Failed to fetch trophies: ${message}`, 3);
+  }
+}
+
+function sortRows(rows: TrophyRow[]): TrophyRow[] {
+  return [...rows].sort((a, b) => {
+    const missingA = a.earned_rate_pct === "" ? 1 : 0;
+    const missingB = b.earned_rate_pct === "" ? 1 : 0;
+    if (missingA !== missingB) {
+      return missingA - missingB;
+    }
+    if (a.hidden !== b.hidden) {
+      return a.hidden === "true" ? 1 : -1;
+    }
+    const rateA = typeof a.earned_rate_pct === "number" ? a.earned_rate_pct : -Infinity;
+    const rateB = typeof b.earned_rate_pct === "number" ? b.earned_rate_pct : -Infinity;
+    return rateB - rateA;
+  });
+}
+
+function toCsvValue(value: string | number | ""): string {
+  const str = value === "" ? "" : String(value);
+  if (str.includes("\"") || str.includes(",") || str.includes("\n")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function writeCsv(filePath: string, rows: TrophyRow[]): void {
+  const headers = [
+    "trophy_id",
+    "name",
+    "description",
+    "rarity_bucket",
+    "earned_rate_pct",
+    "hidden",
+    "icon",
+    "np_communication_id",
+    "group_id",
+  ];
+
+  const lines = [headers.join(",")];
+  for (const row of rows) {
+    const values = headers.map((header) => toCsvValue((row as any)[header] ?? ""));
+    lines.push(values.join(","));
+  }
+
+  fs.writeFileSync(filePath, `${lines.join("\n")}\n`, { encoding: "utf-8" });
+}
+
+async function main(): Promise<void> {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.helpRequested) {
+      printHelp();
+      return;
+    }
+
+    const query = ensureQuery(options);
+    const outFile = options.out ?? `psn_${slugify(query)}_trophies.csv`;
+
+    const npsso = process.env.PSN_NPSSO ?? "";
+    const authorization = await authFromNpsso(npsso);
+    const npCommunicationId = await findNpCommunicationId(authorization, query);
+    const trophies = await fetchTrophies(authorization, npCommunicationId, options.group);
+
+    if (trophies.length === 0) {
+      console.warn("No trophies found for the specified title.");
+    }
+
+    const resolvedOut = path.resolve(outFile);
+    writeCsv(resolvedOut, trophies);
+    console.log(`Wrote ${trophies.length} trophies to ${resolvedOut}.`);
+  } catch (error) {
+    if (error instanceof CliError) {
+      console.error(error.message);
+      process.exit(error.exitCode);
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Unexpected error: ${message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/psn/tsconfig.json
+++ b/psn/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node16",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/steam/.env.example
+++ b/steam/.env.example
@@ -1,0 +1,2 @@
+# Rename to .env and add your Steam Web API key
+STEAM_API_KEY=

--- a/steam/requirements.txt
+++ b/steam/requirements.txt
@@ -1,0 +1,2 @@
+requests
+python-dotenv

--- a/steam/steam_achievements.py
+++ b/steam/steam_achievements.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Fetch Steam global achievement stats and export as CSV."""
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import requests
+from dotenv import load_dotenv
+
+API_GLOBAL_URL = "https://api.steampowered.com/ISteamUserStats/GetGlobalAchievementPercentagesForApp/v2/"
+API_SCHEMA_URL = "https://partner.steam-api.com/ISteamUserStats/GetSchemaForGame/v2/"
+REQUEST_TIMEOUT = 20
+RETRY_STATUS = {500, 502, 503, 504}
+
+
+class SteamCliError(Exception):
+    """Base class for known CLI errors."""
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    examples = (
+        "Examples:\n"
+        "  python steam_achievements.py --appid 620\n"
+        "  python steam_achievements.py --appid 620 --lang french --out portal2_fr.csv"
+    )
+    parser = argparse.ArgumentParser(
+        description="Fetch global Steam achievement stats and merge with schema metadata.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=examples,
+    )
+    parser.add_argument("--appid", type=int, required=True, help="Steam AppID of the game.")
+    parser.add_argument(
+        "--lang",
+        default="english",
+        help="Language for schema metadata (default: english).",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Output CSV path (default: steam_<appid>_achievements.csv).",
+    )
+    return parser
+
+
+def request_json(url: str, *, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    last_error: Optional[str] = None
+    for attempt in range(2):
+        try:
+            response = requests.get(url, params=params, timeout=REQUEST_TIMEOUT)
+        except requests.RequestException as exc:  # network errors
+            last_error = str(exc)
+            continue
+        if response.status_code in RETRY_STATUS and attempt == 0:
+            last_error = f"HTTP {response.status_code}"
+            continue
+        if response.status_code != 200:
+            raise SteamCliError(
+                f"Steam API request failed with status {response.status_code}: {response.text[:200]}"
+            )
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise SteamCliError(f"Failed to parse JSON response: {exc}") from exc
+    raise SteamCliError(f"Network error contacting Steam API: {last_error or 'unknown error'}")
+
+
+def fetch_global_percentages(appid: int) -> Dict[str, float]:
+    params = {"gameid": appid}
+    data = request_json(API_GLOBAL_URL, params=params)
+    achievements = data.get("achievementpercentages", {}).get("achievements", [])
+    result: Dict[str, float] = {}
+    for item in achievements:
+        name = item.get("name")
+        percent = item.get("percent")
+        if not name:
+            continue
+        try:
+            result[name] = float(percent)
+        except (TypeError, ValueError):
+            continue
+    return result
+
+
+def fetch_schema(appid: int, api_key: str, lang: str) -> Dict[str, Dict[str, Any]]:
+    params = {"key": api_key, "appid": appid, "l": lang}
+    data = request_json(API_SCHEMA_URL, params=params)
+    achievements = (
+        data.get("game", {})
+        .get("availableGameStats", {})
+        .get("achievements", [])
+    )
+    schema: Dict[str, Dict[str, Any]] = {}
+    for item in achievements:
+        name = item.get("name")
+        if not name:
+            continue
+        schema[name] = {
+            "title": item.get("displayName", ""),
+            "description": item.get("description", ""),
+            "hidden": bool(item.get("hidden", False)),
+            "icon": item.get("icon", ""),
+            "icon_gray": item.get("icongray", ""),
+        }
+    return schema
+
+
+def sort_rows(rows: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def sort_key(row: Dict[str, Any]) -> Tuple[int, int, float]:
+        percent = row.get("global_percent")
+        missing_percent = 1 if percent in (None, "") else 0
+        hidden = 1 if row.get("hidden") in (True, "true", "True", 1) else 0
+        percent_value = -float(percent) if percent not in (None, "") else 0.0
+        return (missing_percent, hidden, percent_value)
+
+    return sorted(rows, key=sort_key)
+
+
+def write_csv(path: str, rows: Iterable[Dict[str, Any]]) -> None:
+    fieldnames = [
+        "api_name",
+        "title",
+        "description",
+        "hidden",
+        "icon",
+        "icon_gray",
+        "global_percent",
+    ]
+    with open(path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def generate_rows(
+    schema: Dict[str, Dict[str, Any]],
+    global_percentages: Dict[str, float],
+) -> List[Dict[str, Any]]:
+    names = set(schema.keys()) | set(global_percentages.keys())
+    rows: List[Dict[str, Any]] = []
+    for name in names:
+        meta = schema.get(name, {})
+        percent = global_percentages.get(name)
+        rows.append(
+            {
+                "api_name": name,
+                "title": meta.get("title", ""),
+                "description": meta.get("description", ""),
+                "hidden": "true" if meta.get("hidden") else "false",
+                "icon": meta.get("icon", ""),
+                "icon_gray": meta.get("icon_gray", ""),
+                "global_percent": f"{percent:.6f}" if isinstance(percent, float) else "",
+            }
+        )
+    return sort_rows(rows)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    load_dotenv()
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    appid: int = args.appid
+    out_path: str = args.out or f"steam_{appid}_achievements.csv"
+    lang: str = args.lang
+
+    api_key = os.getenv("STEAM_API_KEY")
+    if not api_key:
+        raise SteamCliError("Missing STEAM_API_KEY. Please set it in the environment or .env file.")
+
+    global_percentages = fetch_global_percentages(appid)
+    schema = fetch_schema(appid, api_key, lang)
+
+    if not schema and not global_percentages:
+        write_csv(out_path, [])
+        print("No achievements found for this title. Wrote header-only CSV.")
+        return 0
+
+    rows = generate_rows(schema, global_percentages)
+    write_csv(out_path, rows)
+    print(f"Wrote {len(rows)} achievements to {out_path}.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except SteamCliError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(2 if "Missing STEAM_API_KEY" in str(exc) else 3)
+    except KeyboardInterrupt:
+        print("Aborted by user.", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- add Python CLI for fetching Steam global achievement stats and exporting CSVs
- add TypeScript CLI that authenticates with PSN, resolves titles, and exports trophy data
- document setup and usage for both tools in the repository README

## Testing
- python -m compileall steam

------
https://chatgpt.com/codex/tasks/task_e_68d20203ee78832e85eaddec7a5903ba