### PR TITLE
Enhance PSN scraper tooling debug capabilities

### DIFF
--- a/psn/tools/psn_trophies_from_page.ts
+++ b/psn/tools/psn_trophies_from_page.ts
@@ -34,15 +34,178 @@ function rowsToCsv(rows: Row[]) {
   ].join('\n');
 }
 
-function parseArgs(argv: string[]) {
-  const out: Record<string, string> = {};
+type CliArgs = {
+  url: string;
+  out: string;
+  debug: boolean;
+  debugDir: string;
+  headless: boolean;
+  slowMo: number;
+  profileDir?: string;
+  fallbackUrl?: string;
+};
+
+function parseArgs(argv: string[]): CliArgs {
+  const result: Partial<CliArgs> = {
+    debug: false,
+    headless: true,
+    slowMo: 0,
+    debugDir: path.resolve('debug_artifacts'),
+  };
+  let headlessExplicit = false;
   for (let i = 2; i < argv.length; i++) {
-    if (argv[i] === '--url') out.url = argv[++i];
-    else if (argv[i] === '--out') out.out = argv[++i];
+    const arg = argv[i];
+    switch (arg) {
+      case '--url':
+        result.url = argv[++i];
+        break;
+      case '--out':
+        result.out = path.resolve(argv[++i]);
+        break;
+      case '--debug':
+        result.debug = true;
+        break;
+      case '--debug-dir':
+        result.debugDir = path.resolve(argv[++i]);
+        break;
+      case '--headless': {
+        const value = (argv[++i] || '').toLowerCase();
+        headlessExplicit = true;
+        result.headless = !['false', '0', 'no', 'off'].includes(value);
+        break;
+      }
+      case '--slowmo': {
+        const value = Number(argv[++i]);
+        result.slowMo = Number.isFinite(value) ? value : 0;
+        break;
+      }
+      case '--profile':
+        result.profileDir = path.resolve(argv[++i]);
+        break;
+      case '--fallback-url':
+        result.fallbackUrl = argv[++i];
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
   }
-  if (!out.url) throw new Error('Missing --url');
-  out.out ||= path.resolve(`psn_${new URL(out.url).hostname.replace(/\W+/g,'_')}.csv`);
-  return out as { url: string; out: string; };
+  if (!result.url) throw new Error('Missing --url');
+  if (!result.out) {
+    result.out = path.resolve(`psn_${new URL(result.url).hostname.replace(/\W+/g, '_')}.csv`);
+  }
+  if (result.debug && !headlessExplicit) {
+    result.headless = false;
+  }
+  return result as CliArgs;
+}
+
+type ExtractOptions = {
+  debug: boolean;
+  debugDir: string;
+  headless: boolean;
+  slowMo: number;
+  profileDir?: string;
+  label?: string;
+};
+
+const DEFAULT_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+async function createPage(options: ExtractOptions): Promise<{
+  page: Page;
+  cleanup: () => Promise<void>;
+}> {
+  const cleanupTasks: Array<() => Promise<void>> = [];
+
+  if (options.profileDir) {
+    fs.mkdirSync(options.profileDir, { recursive: true });
+    const context = await chromium.launchPersistentContext(options.profileDir, {
+      headless: options.headless,
+      slowMo: options.slowMo,
+      userAgent: DEFAULT_USER_AGENT,
+      locale: 'en-US',
+      viewport: { width: 1280, height: 720 },
+    });
+    cleanupTasks.push(async () => {
+      await context.close().catch(() => {});
+    });
+    const page = context.pages()[0] ?? (await context.newPage());
+    return {
+      page,
+      cleanup: async () => {
+        for (const task of cleanupTasks.reverse()) {
+          await task();
+        }
+      },
+    };
+  }
+
+  const browser = await chromium.launch({ headless: options.headless, slowMo: options.slowMo });
+  cleanupTasks.push(async () => {
+    await browser.close().catch(() => {});
+  });
+  const context = await browser.newContext({
+    userAgent: DEFAULT_USER_AGENT,
+    locale: 'en-US',
+    viewport: { width: 1280, height: 720 },
+  });
+  cleanupTasks.unshift(async () => {
+    await context.close().catch(() => {});
+  });
+  const page = await context.newPage();
+
+  return {
+    page,
+    cleanup: async () => {
+      for (const task of cleanupTasks) {
+        await task();
+      }
+    },
+  };
+}
+
+async function saveDebugArtifacts(page: Page, options: ExtractOptions, label: string) {
+  if (!options.debug) return;
+  fs.mkdirSync(options.debugDir, { recursive: true });
+  const normalizedLabel = label ? label.replace(/[^a-z0-9_-]+/gi, '_') : 'debug';
+  const baseName = normalizedLabel === 'primary' ? 'debug' : `debug_${normalizedLabel}`;
+  const htmlPath = path.join(options.debugDir, `${baseName}_page.html`);
+  const screenshotPath = path.join(options.debugDir, `${baseName}_screenshot.png`);
+  const content = await page.content();
+  fs.writeFileSync(htmlPath, content, 'utf8');
+  await page.screenshot({ path: screenshotPath, fullPage: true }).catch(() => {});
+  console.log(`Saved debug artifacts to ${htmlPath} and ${screenshotPath}`);
+}
+
+async function attemptCookieConsent(page: Page) {
+  const selectors = [
+    '#onetrust-accept-btn-handler',
+    '#onetrust-accept-all-handler',
+    'button:has-text("Accept")',
+    'button:has-text("Accept All")',
+    'button:has-text("I Agree")',
+    'button:has-text("Agree")',
+    'button[aria-label="Accept"]',
+    'button[aria-label="Accept All"]',
+    'text=Accept all',
+    'text=Allow all',
+  ];
+
+  for (const selector of selectors) {
+    try {
+      const locator = page.locator(selector).first();
+      const count = await locator.count();
+      if (!count) continue;
+      await locator.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {});
+      if (await locator.isVisible().catch(() => false)) {
+        await locator.click({ timeout: 2000 }).catch(() => {});
+        await page.waitForTimeout(500);
+        break;
+      }
+    } catch (err) {
+      // Ignore selector/timeout issues and keep trying the rest
+    }
+  }
 }
 
 function waitForAnySelector(page: Page, selectors: string[], timeout = 20000) {
@@ -393,20 +556,18 @@ async function extractFromExophase(page: Page): Promise<Row[]> {
 
 // --- Router ---
 
-async function extract(url: string): Promise<Row[]> {
-  const browser = await chromium.launch({ headless: true });
-  const page = await browser.newPage({
-
-    userAgent:
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-  });
+async function extract(url: string, options: ExtractOptions): Promise<Row[]> {
+  const label = options.label || new URL(url).hostname;
+  const { page, cleanup } = await createPage(options);
   await page.setExtraHTTPHeaders({
     'Accept-Language': 'en-US,en;q=0.9',
   });
   try {
     await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
     await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+    await attemptCookieConsent(page);
     await page.waitForTimeout(1000);
+    await saveDebugArtifacts(page, options, label);
 
 
     if (/psnprofiles\.com/i.test(url)) return await extractFromPsnProfiles(page);
@@ -444,19 +605,24 @@ async function extract(url: string): Promise<Row[]> {
     }, url);
     return rows;
   } finally {
-    await page.close();
-    await browser.close();
+    await cleanup();
   }
 }
 
 // --- main ---
 (async () => {
-  const { url, out } = parseArgs(process.argv);
-  const rows = await extract(url);
+  const { url, out, debug, debugDir, headless, slowMo, profileDir, fallbackUrl } = parseArgs(process.argv);
+  const commonOptions: ExtractOptions = { debug, debugDir, headless, slowMo, profileDir };
+  let rows = await extract(url, { ...commonOptions, label: 'primary' });
+  if (!rows.length && fallbackUrl) {
+    console.warn(`Primary URL yielded no trophies. Retrying fallback URL: ${fallbackUrl}`);
+    rows = await extract(fallbackUrl, { ...commonOptions, label: 'fallback' });
+  }
   if (!rows.length) {
     console.error('No trophies parsed. The page structure may have changed or the site blocked scraping.');
     process.exit(2);
   }
+  fs.mkdirSync(path.dirname(out), { recursive: true });
   fs.writeFileSync(out, rowsToCsv(rows), 'utf8');
   console.log(`Wrote ${rows.length} trophies to ${out}`);
 })();


### PR DESCRIPTION
## Summary
- add CLI options for debug artifacts, headless control, persistent profiles, slow motion, and fallback URLs in the PSN page scraper tool
- create reusable page helper that supports persistent browser contexts, optional consent handling, and debug screenshots/HTML dumps
- automatically retry with an alternate URL when provided and ensure CSV/debug directories exist before writing

## Testing
- npm --prefix psn run build *(fails: repository currently contains merge conflict markers in src/psn_trophies.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d40f5ed2e0832e9e878b849478767f