### PR TITLE
Refine PSN trophy scraping to ignore comments

### DIFF
--- a/psn/tools/psn_trophies_from_page.ts
+++ b/psn/tools/psn_trophies_from_page.ts
@@ -11,7 +11,7 @@ type Row = {
   trophy_id: string;
   title: string;
   description: string;
-  rarity_percent: number | '';
+  rarity_percent: string;
   rarity_bucket: string;
   hidden: boolean;
   icon: string;
@@ -34,15 +34,178 @@ function rowsToCsv(rows: Row[]) {
   ].join('\n');
 }
 
-function parseArgs(argv: string[]) {
-  const out: Record<string, string> = {};
+type CliArgs = {
+  url: string;
+  out: string;
+  debug: boolean;
+  debugDir: string;
+  headless: boolean;
+  slowMo: number;
+  profileDir?: string;
+  fallbackUrl?: string;
+};
+
+function parseArgs(argv: string[]): CliArgs {
+  const result: Partial<CliArgs> = {
+    debug: false,
+    headless: true,
+    slowMo: 0,
+    debugDir: path.resolve('debug_artifacts'),
+  };
+  let headlessExplicit = false;
   for (let i = 2; i < argv.length; i++) {
-    if (argv[i] === '--url') out.url = argv[++i];
-    else if (argv[i] === '--out') out.out = argv[++i];
+    const arg = argv[i];
+    switch (arg) {
+      case '--url':
+        result.url = argv[++i];
+        break;
+      case '--out':
+        result.out = path.resolve(argv[++i]);
+        break;
+      case '--debug':
+        result.debug = true;
+        break;
+      case '--debug-dir':
+        result.debugDir = path.resolve(argv[++i]);
+        break;
+      case '--headless': {
+        const value = (argv[++i] || '').toLowerCase();
+        headlessExplicit = true;
+        result.headless = !['false', '0', 'no', 'off'].includes(value);
+        break;
+      }
+      case '--slowmo': {
+        const value = Number(argv[++i]);
+        result.slowMo = Number.isFinite(value) ? value : 0;
+        break;
+      }
+      case '--profile':
+        result.profileDir = path.resolve(argv[++i]);
+        break;
+      case '--fallback-url':
+        result.fallbackUrl = argv[++i];
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
   }
-  if (!out.url) throw new Error('Missing --url');
-  out.out ||= path.resolve(`psn_${new URL(out.url).hostname.replace(/\W+/g,'_')}.csv`);
-  return out as { url: string; out: string; };
+  if (!result.url) throw new Error('Missing --url');
+  if (!result.out) {
+    result.out = path.resolve(`psn_${new URL(result.url).hostname.replace(/\W+/g, '_')}.csv`);
+  }
+  if (result.debug && !headlessExplicit) {
+    result.headless = false;
+  }
+  return result as CliArgs;
+}
+
+type ExtractOptions = {
+  debug: boolean;
+  debugDir: string;
+  headless: boolean;
+  slowMo: number;
+  profileDir?: string;
+  label?: string;
+};
+
+const DEFAULT_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+async function createPage(options: ExtractOptions): Promise<{
+  page: Page;
+  cleanup: () => Promise<void>;
+}> {
+  const cleanupTasks: Array<() => Promise<void>> = [];
+
+  if (options.profileDir) {
+    fs.mkdirSync(options.profileDir, { recursive: true });
+    const context = await chromium.launchPersistentContext(options.profileDir, {
+      headless: options.headless,
+      slowMo: options.slowMo,
+      userAgent: DEFAULT_USER_AGENT,
+      locale: 'en-US',
+      viewport: { width: 1280, height: 720 },
+    });
+    cleanupTasks.push(async () => {
+      await context.close().catch(() => {});
+    });
+    const page = context.pages()[0] ?? (await context.newPage());
+    return {
+      page,
+      cleanup: async () => {
+        for (const task of cleanupTasks.reverse()) {
+          await task();
+        }
+      },
+    };
+  }
+
+  const browser = await chromium.launch({ headless: options.headless, slowMo: options.slowMo });
+  cleanupTasks.push(async () => {
+    await browser.close().catch(() => {});
+  });
+  const context = await browser.newContext({
+    userAgent: DEFAULT_USER_AGENT,
+    locale: 'en-US',
+    viewport: { width: 1280, height: 720 },
+  });
+  cleanupTasks.unshift(async () => {
+    await context.close().catch(() => {});
+  });
+  const page = await context.newPage();
+
+  return {
+    page,
+    cleanup: async () => {
+      for (const task of cleanupTasks) {
+        await task();
+      }
+    },
+  };
+}
+
+async function saveDebugArtifacts(page: Page, options: ExtractOptions, label: string) {
+  if (!options.debug) return;
+  fs.mkdirSync(options.debugDir, { recursive: true });
+  const normalizedLabel = label ? label.replace(/[^a-z0-9_-]+/gi, '_') : 'debug';
+  const baseName = normalizedLabel === 'primary' ? 'debug' : `debug_${normalizedLabel}`;
+  const htmlPath = path.join(options.debugDir, `${baseName}_page.html`);
+  const screenshotPath = path.join(options.debugDir, `${baseName}_screenshot.png`);
+  const content = await page.content();
+  fs.writeFileSync(htmlPath, content, 'utf8');
+  await page.screenshot({ path: screenshotPath, fullPage: true }).catch(() => {});
+  console.log(`Saved debug artifacts to ${htmlPath} and ${screenshotPath}`);
+}
+
+async function attemptCookieConsent(page: Page) {
+  const selectors = [
+    '#onetrust-accept-btn-handler',
+    '#onetrust-accept-all-handler',
+    'button:has-text("Accept")',
+    'button:has-text("Accept All")',
+    'button:has-text("I Agree")',
+    'button:has-text("Agree")',
+    'button[aria-label="Accept"]',
+    'button[aria-label="Accept All"]',
+    'text=Accept all',
+    'text=Allow all',
+  ];
+
+  for (const selector of selectors) {
+    try {
+      const locator = page.locator(selector).first();
+      const count = await locator.count();
+      if (!count) continue;
+      await locator.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {});
+      if (await locator.isVisible().catch(() => false)) {
+        await locator.click({ timeout: 2000 }).catch(() => {});
+        await page.waitForTimeout(500);
+        break;
+      }
+    } catch (err) {
+      // Ignore selector/timeout issues and keep trying the rest
+    }
+  }
 }
 
 function waitForAnySelector(page: Page, selectors: string[], timeout = 20000) {
@@ -65,12 +228,14 @@ async function extractFromPsnProfiles(page: Page): Promise<Row[]> {
     '.trophy-card',
     '.trophy-list__item',
     '[data-trophy-id]',
+    'table.zebra tr',
+    'table tr',
   ];
 
   await waitForAnySelector(page, ROW_SELECTORS, 20000);
 
   const rows = await page.evaluate<Row[], { selectors: string[]; href: string }>(
-    ({ selectors, href }) => {
+    ({ selectors, href }: { selectors: string[]; href: string }) => {
       const seen = new Set<Element>();
       const elements: Element[] = [];
       for (const selector of selectors) {
@@ -82,24 +247,66 @@ async function extractFromPsnProfiles(page: Page): Promise<Row[]> {
         }
       }
 
-      const getText = (root: Element, candidates: string[]) => {
+      const normalize = (value: string | null | undefined) =>
+        (value || '').replace(/\s+/g, ' ').trim();
+
+      const getTextWithNode = (root: Element | null, candidates: string[]) => {
+        if (!root) return { text: '', node: null as Element | null };
         for (const candidate of candidates) {
           const target = candidate === ':self' ? root : root.querySelector(candidate);
           if (!target) continue;
-          const value = (target.textContent || '').trim().replace(/\s+/g, ' ');
-          if (value) return value;
+          const value = normalize(target.textContent);
+          if (value) return { text: value, node: target };
         }
-        return '';
+        return { text: '', node: null as Element | null };
       };
 
-      const toNumber = (input: string) => {
+      const gatherDescription = (
+        cell: Element | null,
+        titleElement: HTMLAnchorElement | null,
+        titleText: string,
+      ) => {
+        if (!cell) return '';
+
+        if (titleElement && titleElement.parentElement === cell) {
+          let sibling = titleElement.nextSibling;
+          while (sibling) {
+            if (sibling.nodeType === Node.TEXT_NODE) {
+              const text = normalize(sibling.textContent);
+              if (text) return text;
+            } else if (sibling instanceof Element) {
+              if (sibling.matches('br')) {
+                sibling = sibling.nextSibling;
+                continue;
+              }
+              const text = normalize(sibling.textContent);
+              if (text) return text;
+            }
+            sibling = sibling.nextSibling;
+          }
+        }
+
+        const cellText = normalize(cell.textContent);
+        if (!cellText) return '';
+        let trimmed = cellText;
+        if (titleText) {
+          const idx = trimmed.indexOf(titleText);
+          if (idx !== -1) {
+            trimmed = `${trimmed.slice(0, idx)} ${trimmed.slice(idx + titleText.length)}`;
+          }
+        }
+        trimmed = normalize(trimmed.replace(/^[:\-\s]+/, ''));
+        return trimmed;
+      };
+
+      const toPercentString = (input: string) => {
         const percentMatch = input.match(/(\d+(?:\.\d+)?)%/);
-        if (percentMatch) return Number(percentMatch[1]);
+        if (percentMatch) return `${percentMatch[1]}%`;
         const match = input.match(/(\d+(?:\.\d+)?)/);
-        return match ? Number(match[1]) : '';
+        return match ? `${match[1]}%` : '';
       };
 
-      const toAbsolute = (value: string | null) => {
+      const toAbsolute = (value: string | null | undefined) => {
         if (!value) return '';
         try {
           return new URL(value, href).toString();
@@ -108,9 +315,37 @@ async function extractFromPsnProfiles(page: Page): Promise<Row[]> {
         }
       };
 
+      const isInDisallowedContainer = (el: Element) => {
+        const disallowedSelectors = [
+          '.comment',
+          '.comments',
+          '#comments',
+          '.commentary',
+          '.forum',
+          '#forum',
+          '.message',
+          '.post',
+          '#comment',
+          '.trophy-comments',
+        ];
+        for (const selector of disallowedSelectors) {
+          if (el.closest(selector)) return true;
+        }
+        return false;
+      };
+
       return elements
         .map((el) => {
-          const title = getText(el, [
+          if (!(el instanceof HTMLElement)) return null;
+          if (isInDisallowedContainer(el)) return null;
+          const mainCell =
+            (el.querySelector('td .title')?.closest('td') as HTMLElement | null) ||
+            (el.querySelector('td:nth-child(2)') as HTMLElement | null) ||
+            (el.querySelector('td[style*="width"]') as HTMLElement | null) ||
+            (el.querySelector('td') as HTMLElement | null) ||
+            (el as HTMLElement);
+
+          const { text: title, node: titleNode } = getTextWithNode(mainCell, [
             '.title a',
             '.title',
             '.trophy_title a',
@@ -118,34 +353,56 @@ async function extractFromPsnProfiles(page: Page): Promise<Row[]> {
             '.trophy-card__title a',
             '.trophy-card__title',
             'header .heading',
-            'a[href*="/trophies/"]',
+            'a[href*="/trophy/"]',
             'h3',
             ':self',
           ]);
-          const description = getText(el, [
-            '.small-info',
-            '.trophy_desc',
-            '.info',
-            '.trophy-info',
-            '.trophy-card__description',
-            'p',
-          ]);
-          const rarityText = getText(el, [
-            '.ty-rare',
-            '.rarity',
-            '.small-info .rarity',
-            '.trophy-card__rarity',
-            '.trophy-card__meta',
-          ]);
-          const rarity_percent = toNumber(rarityText);
+          if (!title) return null;
+
+          const titleElement =
+            (titleNode?.closest('a') as HTMLAnchorElement | null) ||
+            (mainCell?.querySelector('a.title, a.trophy_title, .trophy-card__title a, a[href*="/trophy/"]') as
+              | HTMLAnchorElement
+              | null);
+          if (!titleElement) return null;
+
+          const description = gatherDescription(mainCell, titleElement, title);
+
+          const rarityTargets = [
+            el.querySelector('.hover-show .typo-top'),
+            el.querySelector('.hover-show'),
+            el.querySelector('.hover-hide .typo-top'),
+            el.querySelector('.hover-hide'),
+            el.querySelector('.rarity .typo-top'),
+            el.querySelector('.rarity'),
+            el.querySelector('.ty-rare'),
+            el.querySelector('.small-info .rarity'),
+            el.querySelector('.trophy-card__rarity'),
+            el.querySelector('.trophy-card__meta'),
+          ];
+          const rarityText = normalize(
+            rarityTargets.map((node) => normalize(node?.textContent)).find((value) => value) || '',
+          );
+          if (!/%/.test(rarityText)) {
+            return null;
+          }
+          const rarity_percent = toPercentString(rarityText);
           const rarity_bucket = (rarityText.match(/Ultra Rare|Very Rare|Rare|Uncommon|Common|Legendary|Epic/i)?.[0] || '').trim();
-          const iconEl = el.querySelector('img[data-src], img[data-lazy-src], img[src]') as HTMLImageElement | null;
+
+          const iconEl = el.querySelector('img[data-src], img[data-lazy-src], picture img, img[src]') as
+            | HTMLImageElement
+            | null;
           const icon = toAbsolute(
             iconEl?.getAttribute('data-src') ||
               iconEl?.getAttribute('data-lazy-src') ||
               iconEl?.getAttribute('src') ||
               null,
           );
+
+          const titleLink = titleElement;
+          const hrefCandidate = titleLink?.getAttribute('href') ||
+            (el.querySelector('a[href*="/trophy/"]') as HTMLAnchorElement | null)?.getAttribute('href') ||
+            '';
 
           const idSources = [
             el.getAttribute('data-trophy-id'),
@@ -154,8 +411,11 @@ async function extractFromPsnProfiles(page: Page): Promise<Row[]> {
             el.getAttribute('data-key'),
             el.id,
             iconEl?.getAttribute('data-trophy-id') || iconEl?.id || '',
+            hrefCandidate ? hrefCandidate.split('/').filter(Boolean).pop() || '' : '',
+            hrefCandidate ? hrefCandidate.replace(/^\/+/, '') : '',
           ];
-          const trophy_id = idSources.find((value) => value && value.trim())?.trim() || '';
+          const trophy_id =
+            normalize(idSources.find((value) => normalize(value || '')) || '') || normalize(title);
 
           const hidden =
             /hidden|secret/i.test(title) ||
@@ -175,7 +435,7 @@ async function extractFromPsnProfiles(page: Page): Promise<Row[]> {
             source_url: href,
           };
         })
-        .filter((row) => row.title && !/checking your browser/i.test(row.title));
+        .filter((row): row is Row => !!row && !!row.title && !/checking your browser/i.test(row.title));
     },
     { selectors: ROW_SELECTORS, href: page.url() },
   );
@@ -190,7 +450,11 @@ async function extractFromPsnProfiles(page: Page): Promise<Row[]> {
 
   if (deduped.length) return deduped;
 
-  const jsonRows = await page.evaluate<Row[], { href: string }>(({ href }) => {
+  const jsonRows = await page.evaluate<Row[], { href: string }>(({
+    href,
+  }: {
+    href: string;
+  }) => {
     const results: Row[] = [];
     const seenKeys = new Set<string>();
 
@@ -203,14 +467,15 @@ async function extractFromPsnProfiles(page: Page): Promise<Row[]> {
       }
     };
 
-    const toNumber = (value: unknown) => {
-      if (typeof value === 'number' && !Number.isNaN(value)) return value;
+    const toPercentString = (value: unknown) => {
+      if (typeof value === 'number' && !Number.isNaN(value)) {
+        return `${String(value)}%`;
+      }
       if (typeof value === 'string') {
+        const percentMatch = value.match(/(\d+(?:\.\d+)?)%/);
+        if (percentMatch) return `${percentMatch[1]}%`;
         const match = value.match(/(\d+(?:\.\d+)?)/);
-        if (match) {
-          const n = Number(match[1]);
-          if (!Number.isNaN(n)) return n;
-        }
+        if (match) return `${match[1]}%`;
       }
       return '';
     };
@@ -230,13 +495,13 @@ async function extractFromPsnProfiles(page: Page): Promise<Row[]> {
 
       const rarityObj = raw.trophyRare || raw.rarity || raw.trophyRarity || {};
       const rarityPercent =
-        toNumber(raw.trophyEarnedRate) ||
-        toNumber(raw.trophyEarnedRatePercent) ||
-        toNumber(raw.earnedRate) ||
-        toNumber(raw.earnedRatePercentage) ||
-        toNumber(raw.percent) ||
-        toNumber(raw.rarityPercent) ||
-        toNumber(rarityObj.value);
+        toPercentString(raw.trophyEarnedRate) ||
+        toPercentString(raw.trophyEarnedRatePercent) ||
+        toPercentString(raw.earnedRate) ||
+        toPercentString(raw.earnedRatePercentage) ||
+        toPercentString(raw.percent) ||
+        toPercentString(raw.rarityPercent) ||
+        toPercentString(rarityObj.value);
       const rarityBucket =
         (typeof rarityObj === 'object' && rarityObj && typeof rarityObj.name === 'string' && rarityObj.name) ||
         raw.trophyRareName ||
@@ -260,6 +525,8 @@ async function extractFromPsnProfiles(page: Page): Promise<Row[]> {
         (rarityObj && typeof rarityObj === 'object' && rarityObj.iconUrl);
 
       const hiddenValue = raw.trophyHidden ?? raw.isHidden ?? raw.hidden ?? false;
+
+      if (!rarityPercent) return;
 
       results.push({
         trophy_id: trophyIdRaw ? String(trophyIdRaw) : '',
@@ -310,7 +577,9 @@ async function extractFromPsnProfiles(page: Page): Promise<Row[]> {
     };
 
     const scriptNodes = Array.from(
-      document.querySelectorAll('script[type="application/json"], script#__NEXT_DATA__, script#__NUXT_DATA__'),
+      document.querySelectorAll<HTMLScriptElement>(
+        'script[type="application/json"], script#__NEXT_DATA__, script#__NUXT_DATA__',
+      ),
     );
     for (const script of scriptNodes) {
       const text = script.textContent;
@@ -357,18 +626,18 @@ async function extractFromExophase(page: Page): Promise<Row[]> {
         const t = (el.querySelector(sel)?.textContent || '').trim();
         return t.replace(/\s+/g, ' ');
       };
-      const num = (s: string) => {
+      const toPercent = (s: string) => {
         const percentMatch = s.match(/(\d+(?:\.\d+)?)%/);
-        if (percentMatch) return Number(percentMatch[1]);
-        const m = s.match(/(\d+(\.\d+)?)/);
-        return m ? Number(m[1]) : '';
+        if (percentMatch) return `${percentMatch[1]}%`;
+        const m = s.match(/(\d+(?:\.\d+)?)/);
+        return m ? `${m[1]}%` : '';
       };
 
       return elements.map((el) => {
         const title = text(el, '.award__title, .game__achievement__title');
         const description = text(el, '.award__desc, .game__achievement__desc');
         const rarityText = text(el, '.award__rarity, .game__achievement__rarity');
-        const rarityPercent = num(rarityText);
+        const rarityPercent = toPercent(rarityText);
         const bucket = (rarityText.match(/Ultra Rare|Very Rare|Rare|Uncommon|Common/i)?.[0] || '').trim();
         const hidden = /secret|hidden/i.test(title) || /secret|hidden/i.test(description);
         const icon = (el.querySelector('img') as HTMLImageElement | null)?.src || '';
@@ -388,25 +657,23 @@ async function extractFromExophase(page: Page): Promise<Row[]> {
     },
     page.url(),
   );
-  return rows.filter(r => r.title);
+  return rows.filter((r) => r.title && r.rarity_percent);
 }
 
 // --- Router ---
 
-async function extract(url: string): Promise<Row[]> {
-  const browser = await chromium.launch({ headless: true });
-  const page = await browser.newPage({
-
-    userAgent:
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-  });
+async function extract(url: string, options: ExtractOptions): Promise<Row[]> {
+  const label = options.label || new URL(url).hostname;
+  const { page, cleanup } = await createPage(options);
   await page.setExtraHTTPHeaders({
     'Accept-Language': 'en-US,en;q=0.9',
   });
   try {
     await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
     await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+    await attemptCookieConsent(page);
     await page.waitForTimeout(1000);
+    await saveDebugArtifacts(page, options, label);
 
 
     if (/psnprofiles\.com/i.test(url)) return await extractFromPsnProfiles(page);
@@ -414,14 +681,14 @@ async function extract(url: string): Promise<Row[]> {
 
     // Generic fallback: scan DOM for trophy-like rows
     await page.waitForTimeout(1500);
-    const rows: Row[] = await page.evaluate<Row[], string>((href) => {
-      function num(s: string) {
+    const rows: Row[] = await page.evaluate<Row[], string>((href: string) => {
+      function toPercent(s: string) {
         const percentMatch = s.match(/(\d+(?:\.\d+)?)%/);
-        if (percentMatch) return Number(percentMatch[1]);
-        const m = s.match(/(\d+(\.\d+)?)/);
-        return m ? Number(m[1]) : '';
+        if (percentMatch) return `${percentMatch[1]}%`;
+        const m = s.match(/(\d+(?:\.\d+)?)/);
+        return m ? `${m[1]}%` : '';
       }
-      const candidates = Array.from(document.querySelectorAll('tr, .card, .trophy'));
+      const candidates = Array.from(document.querySelectorAll<Element>('tr, .card, .trophy'));
       const out: any[] = [];
       for (const el of candidates) {
         const title = (el.querySelector('h3, .title, .trophy_title, a')?.textContent || '').trim();
@@ -432,7 +699,7 @@ async function extract(url: string): Promise<Row[]> {
             trophy_id: (el.getAttribute('data-id') || '').toString(),
             title,
             description: desc,
-            rarity_percent: num(rarityText),
+            rarity_percent: toPercent(rarityText),
             rarity_bucket: (rarityText.match(/Ultra Rare|Very Rare|Rare|Uncommon|Common/i)?.[0] || '').trim(),
             hidden: /hidden|secret/i.test(title) || /hidden|secret/i.test(desc),
             icon: (el.querySelector('img') as HTMLImageElement | null)?.src || '',
@@ -444,19 +711,24 @@ async function extract(url: string): Promise<Row[]> {
     }, url);
     return rows;
   } finally {
-    await page.close();
-    await browser.close();
+    await cleanup();
   }
 }
 
 // --- main ---
 (async () => {
-  const { url, out } = parseArgs(process.argv);
-  const rows = await extract(url);
+  const { url, out, debug, debugDir, headless, slowMo, profileDir, fallbackUrl } = parseArgs(process.argv);
+  const commonOptions: ExtractOptions = { debug, debugDir, headless, slowMo, profileDir };
+  let rows = await extract(url, { ...commonOptions, label: 'primary' });
+  if (!rows.length && fallbackUrl) {
+    console.warn(`Primary URL yielded no trophies. Retrying fallback URL: ${fallbackUrl}`);
+    rows = await extract(fallbackUrl, { ...commonOptions, label: 'fallback' });
+  }
   if (!rows.length) {
     console.error('No trophies parsed. The page structure may have changed or the site blocked scraping.');
     process.exit(2);
   }
+  fs.mkdirSync(path.dirname(out), { recursive: true });
   fs.writeFileSync(out, rowsToCsv(rows), 'utf8');
   console.log(`Wrote ${rows.length} trophies to ${out}`);
 })();

--- a/psn/tsconfig.json
+++ b/psn/tsconfig.json
@@ -6,6 +6,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "strict": true,
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "."
   },


### PR DESCRIPTION
## Summary
- Tightened the PSNProfiles DOM scraper to only keep trophy rows, harvesting descriptions from the text immediately after each title link and skipping rows inside comment containers.
- Normalized rarity percentage handling to emit percent strings across all extractor paths and drop rows missing a percent value.

## Testing
- npm --prefix psn run build *(fails: repository already contains merge conflict markers in src/psn_trophies.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d40f5ed2e0832e9e878b849478767f